### PR TITLE
Fix rendering of multiple links per markdown token

### DIFF
--- a/zobsidian.js
+++ b/zobsidian.js
@@ -57,7 +57,8 @@ class importMarkdownForm extends FormApplication {
 	    title = name.match( /([^\/]+)$/ )[1];
 	  }
 	  env.renderChildren.push( { name: name, title: title } );
-	  return `<span class="zlink">@JournalEntry[zid=${name}]{${title}}</span>`;
+          let htmlLink = `<span class="zlink">@JournalEntry[zid=${name}]{${title}}</span>`;
+          html = html.replaceAll(link, htmlLink);
 	}
 	return html;
       }


### PR DESCRIPTION
This commit fixes a problem with importing markdown documents that have more than one link per markdown token. 

Example markdown text:
```
This town has some nice places: A [[places/flower garden|flower garden]] and a [[places/gate to hell|gate to hell]].
```

generated html before the fix:

```html
<span class="zlink">@JournalEntry[zid=INTERNAL_LINK]{flower garden}</span>
```

and after this commit:

```html
This town has some nice places: A <span class="zlink">@JournalEntry[zid=INTERNAL_LINK]{flower garden}</span> and a <span class="zlink">@JournalEntry[zid=INTERNAL_LINK]{gate to hell}</span>.
```
